### PR TITLE
feat(device-aware): add DeviceAwareController and node condition informer

### DIFF
--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -155,6 +155,8 @@ func parse() (bool, *controller.Configuration, error) {
 
 	ai := flags.String("ai", "openai", "backend AI Provider")
 
+	enableDeviceAware := flags.Bool("device-aware.enable", false, "enable device aware")
+
 	showVersion := flags.Bool("version", false, "Show release info.")
 
 	flags.AddGoFlagSet(flag.CommandLine)
@@ -203,6 +205,7 @@ func parse() (bool, *controller.Configuration, error) {
 		CollectorImage:            *collectorImage,
 		EnableProm:                *enableProm,
 		AiBackend:                 *ai,
+		EnableDeviceAware:         *enableDeviceAware,
 	}
 
 	return false, config, nil

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --diagnosis.cache=true
         - --diagnosis.language=chinese
         - --diagnosis.collector-image=registry-ap-southeast.scitix.ai/k8s/aegis-collector:v1.0.0
+        - device-aware.enable=true
         - --config=/aegis/config/config.yaml
         - --web.route-prefix=/
         - --v=4

--- a/internal/device_aware/device_aware.go
+++ b/internal/device_aware/device_aware.go
@@ -1,0 +1,178 @@
+package deviceaware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/scitix/aegis/pkg/prom"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	AEGIS_DEVICE_ANNOTATION = "aegis.io/device-errors"
+)
+
+type DeviceAwareController struct {
+	informer *NodeStatusInformer
+	handler  *NodeStatusHandler
+}
+
+type NodeStatusHandler struct {
+	kubeClient clientset.Interface
+	nodeLister corelisters.NodeLister
+	nodeSynced cache.InformerSynced
+}
+
+func (h *NodeStatusHandler) OnAdd(new *NodeStatus) {
+	klog.Infof("[NODE ADD/UPDATE] %s status: %v", new.NodeName, new.StatusMap)
+
+	node, err := h.nodeLister.Get(new.NodeName)
+	if err != nil {
+		klog.Errorf("failed to get node %s, %v", new.NodeName, err)
+		return
+	}
+
+	value, err := json.Marshal(new.StatusMap)
+	if err != nil {
+		klog.Errorf("failed to marshal status map %v, %v", new.StatusMap, err)
+		return
+	}
+
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations[AEGIS_DEVICE_ANNOTATION] = string(value)
+
+	_, err = h.kubeClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("failed to update node %s, %v", new.NodeName, err)
+		return
+	}
+}
+
+func (h *NodeStatusHandler) OnUpdate(old, new *NodeStatus) {
+	h.OnAdd(new)
+}
+
+func (h *NodeStatusHandler) OnDelete(old *NodeStatus) {
+	klog.Infof("[NODE DELETE] %s status: %v", old.NodeName, old.StatusMap)
+	node, err := h.nodeLister.Get(old.NodeName)
+	if err != nil {
+		klog.Errorf("failed to get node %s, %v", old.NodeName, err)
+		return
+	}
+
+	if node.Annotations[AEGIS_DEVICE_ANNOTATION] != "" {
+		delete(node.Annotations, AEGIS_DEVICE_ANNOTATION)
+	}
+
+	_, err = h.kubeClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("failed to update node %s, %v", old.NodeName, err)
+		return
+	}
+}
+
+func InitDeviceStatusCache(kubeclient clientset.Interface) (map[string]*NodeStatus, error) {
+	statuses := make(map[string]*NodeStatus)
+	nodes, err := kubeclient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	for _, node := range nodes.Items {
+		annotations := node.Annotations
+		if annotations == nil {
+			continue
+		}
+
+		if status, ok := annotations[AEGIS_DEVICE_ANNOTATION]; ok {
+			s := make(map[DeviceType]string)
+			err := json.Unmarshal([]byte(status), &s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal node %s device status: %v", node.Name, err)
+			}
+
+			vm := make(map[DeviceType]int64)
+			vs := make([]int64, 0)
+			for d, ds := range s {
+				hash := hashStringToInt64(ds)
+				vm[d] = hash
+				vs = append(vs, hash)
+			}
+
+			statuses[node.Name] = &NodeStatus{
+				NodeName:   node.Name,
+				StatusMap:  s,
+				Version:    hashInt64SliceToInt64(vs),
+				VersionMap: vm,
+				Timestamp:  time.Now(),
+			}
+		}
+	}
+
+	return statuses, nil
+}
+
+func NewController(kubeclient clientset.Interface,
+	nodeInformer coreinformers.NodeInformer) (*DeviceAwareController, error) {
+
+	cache, err := InitDeviceStatusCache(kubeclient)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).Info("device status cache initialized:")
+	for node, status := range cache {
+		klog.V(4).Infof("	node %s: %+v", node, status)
+	}
+
+	handler := &NodeStatusHandler{
+		kubeClient: kubeclient,
+		nodeLister: nodeInformer.Lister(),
+		nodeSynced: nodeInformer.Informer().HasSynced,
+	}
+
+	informer := NewNodeStatusInformer(
+		prom.GetPromAPI(),
+		handler,
+		cache,
+		[]DeviceType{
+			DeviceTypeBaseboard,
+			DeviceTypeCPU,
+			DeviceTypeMemory,
+			DeviceTypeDisk,
+			DeviceTypeNetwork,
+			DeviceTypeIB,
+			DeviceTypeGPU,
+		},
+		10*time.Second,
+	)
+
+	controller := &DeviceAwareController{
+		handler:  handler,
+		informer: informer,
+	}
+
+	return controller, nil
+}
+
+func (d *DeviceAwareController) Run(ctx context.Context) error {
+	klog.Info("Waiting for node informer caches to sync")
+	if ok := cache.WaitForNamedCacheSync("node", ctx.Done(), d.handler.nodeSynced); !ok {
+		return fmt.Errorf("failed to wait for node cache to sync")
+	}
+
+	go d.informer.Run(ctx)
+
+	<-ctx.Done()
+	klog.Info("Stopping device aware worker")
+	return nil
+}

--- a/internal/device_aware/node_condition_informer.go
+++ b/internal/device_aware/node_condition_informer.go
@@ -1,0 +1,454 @@
+package deviceaware
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"crypto/sha256"
+	"encoding/binary"
+
+	"github.com/scitix/aegis/internal/selfhealing/sop/basic"
+	"github.com/scitix/aegis/pkg/prom"
+	"k8s.io/klog/v2"
+)
+
+type DeviceType string
+
+const (
+	DeviceTypeGPU       DeviceType = "gpu"
+	DeviceTypeIB        DeviceType = "ib"
+	DeviceTypeCPU       DeviceType = "cpu"
+	DeviceTypeMemory    DeviceType = "memory"
+	DeviceTypeNetwork   DeviceType = "network"
+	DeviceTypeSystem    DeviceType = "system"
+	DeviceTypeDisk      DeviceType = "disk"
+	DeviceTypeDefault   DeviceType = "default"
+	DeviceTypeBaseboard DeviceType = "baseboard"
+)
+
+// 节点状态集合
+type NodeStatus struct {
+	NodeName   string
+	StatusMap  map[DeviceType]string // 存储各维度状态（例如：gpu、ib、cpu）
+	Version    int64                 // 全局版本号
+	VersionMap map[DeviceType]int64
+	Timestamp  time.Time
+}
+
+// 事件处理器接口
+type NodeStatusEventHandler interface {
+	OnAdd(status *NodeStatus)
+	OnUpdate(old, new *NodeStatus)
+	OnDelete(status *NodeStatus)
+}
+
+// 复合型Informer
+type NodeStatusInformer struct {
+	client       *prom.PromAPI
+	cache        map[string]*NodeStatus // key: node name
+	cacheLock    sync.RWMutex
+	handler      NodeStatusEventHandler
+	resyncPeriod time.Duration
+	types        []DeviceType // 监控的设备类型
+}
+
+func NewNodeStatusInformer(client *prom.PromAPI, handler NodeStatusEventHandler, cache map[string]*NodeStatus, types []DeviceType, resyncPeriod time.Duration) *NodeStatusInformer {
+	return &NodeStatusInformer{
+		client:       client,
+		cache:        cache,
+		handler:      handler,
+		resyncPeriod: resyncPeriod,
+		types:        types,
+	}
+}
+
+// 主运行循环
+func (i *NodeStatusInformer) Run(ctx context.Context) {
+	ticker := time.NewTicker(i.resyncPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			i.fullSync(ctx)
+		}
+	}
+}
+
+// 全量同步
+func (i *NodeStatusInformer) fullSync(ctx context.Context) {
+	current, err := i.fetchAllStatus(ctx)
+	if err != nil {
+		klog.Errorf("Error fetching status: %v\n", err)
+		return
+	}
+
+	i.cacheLock.Lock()
+	defer i.cacheLock.Unlock()
+
+	// 预防性阻塞
+	if len(i.cache) > 2 && len(current) == 0 {
+		klog.Warningf("存量节点设备异常数：%d， 当前所有节点状态为空, 等待下次同步", len(i.cache))
+		return
+	}
+
+	// 处理删除和更新
+	for nodeName, oldStatus := range i.cache {
+		if newStatus, exists := current[nodeName]; exists {
+			if newStatus.Version != oldStatus.Version {
+				i.handler.OnUpdate(oldStatus, newStatus)
+				i.cache[nodeName] = newStatus
+			}
+		} else {
+			// 创建删除标记状态
+			i.handler.OnDelete(oldStatus)
+			delete(i.cache, nodeName)
+		}
+	}
+
+	// 处理新增
+	for nodeName, newStatus := range current {
+		if _, exists := i.cache[nodeName]; !exists {
+			i.handler.OnAdd(newStatus)
+			i.cache[nodeName] = newStatus
+		}
+	}
+}
+
+// 获取所有监控指标的状态
+func (i *NodeStatusInformer) fetchAllStatus(ctx context.Context) (map[string]*NodeStatus, error) {
+	result := make(map[string]*NodeStatus)
+
+	// 并发获取所有指标
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+	errChan := make(chan error, len(i.types))
+
+	for _, deviceType := range i.types {
+		wg.Add(1)
+		go func(t DeviceType) {
+			defer wg.Done()
+
+			data, err := i.queryMetric(ctx, deviceType)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			mutex.Lock()
+			defer mutex.Unlock()
+			for node, status := range data {
+				if existing, ok := result[node]; ok {
+					// 合并状态
+					for k, v := range status.StatusMap {
+						existing.StatusMap[k] = v
+						existing.VersionMap[k] = status.Version
+					}
+					// 取最新时间戳
+					if status.Timestamp.After(existing.Timestamp) {
+						existing.Timestamp = status.Timestamp
+					}
+				} else {
+					result[node] = status
+				}
+			}
+		}(deviceType)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	if len(errChan) > 0 {
+		return nil, fmt.Errorf("error fetching metrics: %v", <-errChan)
+	}
+
+	for node, status := range result {
+		vs := make([]int64, 0)
+		for _, version := range status.VersionMap {
+			vs = append(vs, version)
+		}
+
+		result[node].Version = hashInt64SliceToInt64(vs)
+	}
+
+	return result, nil
+}
+
+func hashInt64SliceToInt64(vs []int64) int64 {
+	// 排序
+	sort.Slice(vs, func(i, j int) bool {
+		return vs[i] < vs[j]
+	})
+
+	data := make([]byte, 0, 8*len(vs))
+	for _, v := range vs {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, uint64(v))
+		data = append(data, b...)
+	}
+
+	return hashStringToInt64(string(data))
+}
+
+func hashStringToInt64(s string) int64 {
+	h := sha256.Sum256([]byte(s))
+	// 取前8字节转成 int64
+	return int64(binary.BigEndian.Uint64(h[:8]))
+}
+
+// 查询单个类型指标
+func (i *NodeStatusInformer) queryMetric(ctx context.Context, deviceType DeviceType) (map[string]*NodeStatus, error) {
+	query := fmt.Sprintf("aegis_node_status_condition{type=\"%s\"}", deviceType)
+	results, err := i.client.ListNodeStatusesWithQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeStatuses := make(map[string][]prom.AegisNodeStatus)
+	for i, result := range results {
+		node := result.Name
+		if len(nodeStatuses[node]) > 0 {
+			nodeStatuses[node] = append(nodeStatuses[node], results[i])
+		} else {
+			nodeStatuses[node] = []prom.AegisNodeStatus{results[i]}
+		}
+	}
+
+	statusMap := make(map[string]*NodeStatus)
+
+	for node, statuses := range nodeStatuses {
+		// 根据指标类型解析值
+		var s string
+		switch deviceType {
+		case DeviceTypeBaseboard:
+			s = parseBaseboardStatus(statuses)
+		case DeviceTypeCPU:
+			s = parseCPUStatus(statuses)
+		case DeviceTypeMemory:
+			s = parseMemoryStatus(statuses)
+		case DeviceTypeDisk:
+			s = parseDiskStatus(statuses)
+		case DeviceTypeGPU:
+			s = parseGPUStatus(statuses)
+		case DeviceTypeIB:
+			s = parseIBDeviceStatus(statuses)
+		case DeviceTypeNetwork:
+			s = parseNetworkStatus(statuses)
+		default:
+			klog.Warningf("unsupported device type: %s", deviceType)
+		}
+
+		if s != "" {
+			if _, exists := statusMap[node]; !exists {
+				statusMap[node] = &NodeStatus{
+					NodeName:  node,
+					StatusMap: make(map[DeviceType]string),
+					Timestamp: time.Now(),
+				}
+			}
+			statusMap[node].StatusMap[deviceType] = s
+
+			// 版本签名
+			statusMap[node].VersionMap = map[DeviceType]int64{
+				deviceType: hashStringToInt64(s),
+			}
+		}
+	}
+
+	return statusMap, nil
+}
+
+// baseboard 设备状态解析
+func parseBaseboardStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]string, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeBaseBoardCriticalIssue):
+			if status.ID != "" {
+				disabled = append(disabled, status.ID)
+			}
+		default:
+			continue
+		}
+	}
+
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}
+
+// cpu 设备状态解析
+func parseCPUStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]string, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeCpuUnhealthy):
+			if status.ID != "" {
+				disabled = append(disabled, status.ID)
+			}
+		default:
+			continue
+		}
+	}
+
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}
+
+// memory 设备状态解析
+func parseMemoryStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]string, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeMemoryUnhealthy):
+			if status.ID != "" {
+				disabled = append(disabled, status.ID)
+			}
+		default:
+			continue
+		}
+	}
+
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}
+
+// disk 设备状态解析
+func parseDiskStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]string, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeDiskPressure):
+			fallthrough
+		case string(basic.ConditionTypeDiskUnhealthy):
+			if status.ID != "" {
+				disabled = append(disabled, status.ID)
+			}
+		default:
+			continue
+		}
+	}
+
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}
+
+// network 设备状态解析
+func parseNetworkStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]string, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeNetworkLinkDown):
+			if status.ID != "" {
+				disabled = append(disabled, status.ID)
+			}
+		default:
+			continue
+		}
+	}
+
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}
+
+// gpu 设备状态解析
+func parseGPUStatus(statuses []prom.AegisNodeStatus) string {
+	disabled := make([]bool, 8)
+
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeGpuNvlinkInactive):
+			fallthrough
+		case string(basic.ConditionTypeGpuHung):
+			for i, _ := range disabled {
+				disabled[i] = true
+			}
+		case string(basic.ConditionTypeGpuCheckFailed):
+			if status.ID != "" {
+				for i, ch := range status.ID {
+					num, err := strconv.ParseBool(string(ch))
+					if err != nil {
+						klog.Warningf("parse gpu index %d status %c failed: %s", i, ch, err)
+						continue
+					}
+
+					disabled[i] = num
+				}
+			}
+		case string(basic.ConditionTypeGpuDown):
+			fallthrough
+		case string(basic.ConditionTypeGpuTooManyPageRetired):
+			fallthrough
+		case string(basic.ConditionTypeGpuRowRemappingFailure):
+			fallthrough
+		case string(basic.ConditionTypeGpuAggSramUncorrectable):
+			fallthrough
+		case string(basic.ConditionTypeGpuVolSramUncorrectable):
+			fallthrough
+		case string(basic.ConditionTypeGpuGpuHWSlowdown):
+			fallthrough
+		case string(basic.ConditionTypeXIDHWSystemErr):
+			if status.ID != "" {
+				id, err := strconv.Atoi(status.ID)
+				if err != nil || id > 7 {
+					klog.Warningf("parse gpu index %s failed or invalid: %s", status.ID, err)
+				} else {
+					disabled[id] = true
+				}
+			}
+		case string(basic.ConditionTypeGpuPcieDowngraded):
+			fallthrough
+		case string(basic.ConditionTypeHighGpuTemp):
+			fallthrough
+		case string(basic.ConditionTypeHighGpuMemoryTemp):
+			fallthrough
+		case string(basic.ConditionTypeXIDECCMemoryErr):
+			fallthrough
+		case string(basic.ConditionTypeGpuVolDramUncorrectable):
+			fallthrough
+		case string(basic.ConditionTypeGpuRegisterFailed):
+			continue
+		default:
+			klog.Warningf("unsupported condition type %s", status.Type)
+		}
+	}
+
+	indexs := make([]string, 0)
+	for i, disable := range disabled {
+		if disable {
+			indexs = append(indexs, fmt.Sprintf("%d", i))
+		}
+	}
+
+	return strings.Join(indexs, ",")
+}
+
+// ib 设备状态解析
+func parseIBDeviceStatus(statuses []prom.AegisNodeStatus) string {
+	disabledMap := make(map[string]bool, 0)
+	for _, status := range statuses {
+		switch status.Condition {
+		case string(basic.ConditionTypeIBDown):
+			fallthrough
+		case string(basic.ConditionTypeIBLinkFrequentDown):
+			if status.ID != "" {
+				disabledMap[status.ID] = true
+			}
+		default:
+			continue
+		}
+	}
+
+	disabled := make([]string, 0)
+	for id, _ := range disabledMap {
+		disabled = append(disabled, id)
+	}
+	sort.Strings(disabled)
+	return strings.Join(disabled, ",")
+}

--- a/internal/selfhealing/sop/basic/type.go
+++ b/internal/selfhealing/sop/basic/type.go
@@ -17,7 +17,7 @@ var repair_job_file string = filepath.Join(job_dir, "repair_node.yaml")
 var remedy_job_file string = filepath.Join(job_dir, "remedy_node.yaml")
 var perf_job_file string = filepath.Join(job_dir, "perf_node.yaml")
 
-var SleepWaitDuration = time.Hour * time.Duration(1)
+var SleepWaitDuration = time.Minute * time.Duration(30)
 
 const (
 	SystemNamespace = "kube-system"
@@ -60,76 +60,87 @@ const (
 	ComponentTypeDcgmExporter       = "dcgm-exporter"
 	ComponentTypeNvidiaDevicePlugin = "nvidia-device-plugin"
 	ComponentTypeRdmaDevicePlugin   = "rdma-device-plugin"
+	ComponentTypeRoceDevicePlugin   = "kube-sriov-device-plugin"
 )
 
 type ConditionType string
 
 const (
 	ConditionTypeNull                            ConditionType = "NULL"
-	ConditionTypeBaseBoardCriticalIssue          ConditionType = "BaseBoardCriticalIssue"
-	ConditionTypeCPUPressure                     ConditionType = "CPUPressure"
-	ConditionTypeCpuUnhealthy                    ConditionType = "CpuUnhealthy"
-	ConditionTypeDiskUnhealthy                   ConditionType = "DiskUnhealthy"
-	ConditionTypeGpfsTestFailed                  ConditionType = "GpfsTestFailed"
-	ConditionTypeGpfsIBNotConfig                 ConditionType = "GpfsIBNotConfig"
-	ConditionTypeGpfsThreadDeadlock              ConditionType = "GpfsThreadDeadlock"
-	ConditionTypeGpfsDown                        ConditionType = "GpfsDown"
-	ConditionTypeGpfsMountLost                   ConditionType = "GpfsMountLost"
-	ConditionTypeGpfsInactive                    ConditionType = "GpfsInactive"
-	ConditionTypeGpfsRdmaStatusError             ConditionType = "GpfsRdmaStatusError"
-	ConditionTypeGpfsQuorumConnectionDown        ConditionType = "GpfsQuorumConnectionDown"
-	ConditionTypeGpfsExpelledFromCluster         ConditionType = "GpfsExpelledFromCluster"
-	ConditionTypeGpfsTimeClockError              ConditionType = "GpfsTimeClockError"
-	ConditionTypeGpfsOsLockup                    ConditionType = "GpfsOsLockup"
-	ConditionTypeGpfsBadTcpState                 ConditionType = "GpfsBadTcpState"
-	ConditionTypeGpfsUnauthorized                ConditionType = "GpfsUnauthorized"
-	ConditionTypeGpfsBond0Lost                   ConditionType = "GpfsBond0Lost"
-	ConditionTypeGpuApplicationFrequentError     ConditionType = "GpuApplicationFrequentError"
-	ConditionTypeGpuHung                         ConditionType = "GpuHung"
-	ConditionTypeGpuCheckFailed                  ConditionType = "GpuCheckFailed"
-	ConditionTypeGpuDown                         ConditionType = "GpuDown"
-	ConditionTypeXIDECCMemoryErr                 ConditionType = "XIDECCMemoryErr"
-	ConditionTypeXIDHWSystemErr                  ConditionType = "XIDHWSystemErr"
-	ConditionTypeXIDUnclassifiedErr              ConditionType = "XIDUnclassifiedErr"
-	ConditionTypeGpuMetricsHang                  ConditionType = "GpuMetricsHang"
-	ConditionTypeGpuTooManyPageRetired           ConditionType = "GpuTooManyPageRetired"
-	ConditionTypeGpuPcieDowngraded               ConditionType = "GpuPcieDowngraded"
-	ConditionTypeGpuRegisterFailed               ConditionType = "GpuRegisterFailed"
-	ConditionTypeGpuRowRemappingPending          ConditionType = "GpuRowRemappingPending"
-	ConditionTypeGpuRowRemappingFailure          ConditionType = "GpuRowRemappingFailure"
-	ConditionTypeGpuSramUncorrectable            ConditionType = "GpuSramUncorrectable"
-	ConditionTypeGpuAggSramUncorrectable         ConditionType = "GpuAggSramUncorrectable"
-	ConditionTypeGpuVolSramUncorrectable         ConditionType = "GpuVolSramUncorrectable"
-	ConditionTypeGpuVolDramUncorrectable         ConditionType = "GpuVolDramUncorrectable"
-	ConditionTypeGpuVolDramCorrectable           ConditionType = "GpuVolDramCorrectable"
-	ConditionTypeGpuNvlinkInactive               ConditionType = "GPUNvlinkInactive"
-	ConditionTypeGpuGpuHWSlowdown                ConditionType = "GPUHWSlowdown"
-	ConditionTypeGPUPersistenceModeNotEnabled    ConditionType = "GPUPersistenceModeNotEnabled"
-	ConditionTypeHighGpuMemoryTemp               ConditionType = "HighGpuMemoryTemp"
-	ConditionTypeHighGpuTemp                     ConditionType = "HighGpuTemp"
-	ConditionTypeIBDown                          ConditionType = "IBDown"
-	ConditionTypeRoceDeviceBroken                ConditionType = "RoceDeviceBroken"
-	ConditionTypeIBLinkFrequentDown              ConditionType = "IBLinkFrequentDown"
-	ConditionTypeIBPcieDowngraded                ConditionType = "IBPcieDowngraded"
-	ConditionTypeIBModuleNotInstalled            ConditionType = "IBModuleNotInstalled"
-	ConditionTypeIBRegisterFailed                ConditionType = "IBRegisterFailed"
-	ConditionTypeRoceRegisterFailed              ConditionType = "RoceRegisterFailed"
-	ConditionTypeIBSymbolError                   ConditionType = "IBSymbolError"
-	ConditionTypeMemoryPressure                  ConditionType = "MemoryPressure"
-	ConditionTypeKubeletMemoryPressure           ConditionType = "KubeletMemoryPressure"
-	ConditionTypeMemoryUnhealthy                 ConditionType = "MemoryUnhealthy"
-	ConditionTypeNetworkLinkFrequentDown         ConditionType = "NetworkLinkFrequentDown"
-	ConditionTypeNetworkLinkTooManyDown          ConditionType = "NetworkLinkTooManyDown"
-	ConditionTypeNetworkICETXTimeout             ConditionType = "ICETxTimeout"
+	
+	// baseboard
+	ConditionTypeBaseBoardCriticalIssue ConditionType = "BaseBoardCriticalIssue"
+
+	// cpu
+	ConditionTypeCPUPressure  ConditionType = "CPUPressure"
+	ConditionTypeCpuUnhealthy ConditionType = "CpuUnhealthy"
+
+	// disk
+	ConditionTypeDiskPressure  ConditionType = "DiskPressure"
+	ConditionTypeDiskUnhealthy ConditionType = "DiskUnhealthy"
+
+	// memory
+	ConditionTypeMemoryPressure        ConditionType = "MemoryPressure"
+	ConditionTypeKubeletMemoryPressure ConditionType = "KubeletMemoryPressure"
+	ConditionTypeMemoryUnhealthy       ConditionType = "MemoryUnhealthy"
+
+	// network
+	ConditionTypeNetworkLinkDown ConditionType = "NetworkLinkDown"
+
+	// system
+	ConditionTypeHighZombieProcessesCount ConditionType = "HighZombieProcessesCount"
+
+	// ib
+	ConditionTypeIBLinkFrequentDown ConditionType = "IBLinkFrequentDown"
+	ConditionTypeIBDown             ConditionType = "IBDown"
+	ConditionTypeIBRegisterFailed   ConditionType = "IBRegisterFailed"
+	ConditionTypeIBPcieDowngraded   ConditionType = "IBPcieDowngraded"
+	ConditionTypeRoceRegisterFailed ConditionType = "RoceRegisterFailed"
+	ConditionTypeRoceDeviceBroken   ConditionType = "RoceDeviceBroken"
+
+	// gpfs
+	ConditionTypeGpfsDown           ConditionType = "GpfsDown"
+	ConditionTypeGpfsMountLost      ConditionType = "GpfsMountLost"
+	ConditionTypeGpfsThreadDeadlock ConditionType = "GpfsThreadDeadlock"
+	ConditionTypeGpfsTestFailed     ConditionType = "GpfsTestFailed"
+	ConditionTypeGpfsRdmaError      ConditionType = "GpfsRdmaError"
+	ConditionTypeGpfsNodeNotHealthy ConditionType = "GpfsNodeNotHealthy"
+	ConditionTypeGpfsNotMounted     ConditionType = "GpfsNotMounted"
+	ConditionTypeGpfsNotStarted     ConditionType = "GpfsNotStarted"
+	ConditionTypeGpfsNotInCluster   ConditionType = "GpfsNotInCluster"
+	ConditionTypeGpfsNotInstalled   ConditionType = "GpfsNotInstalled"
+	ConditionTypeGpfsIBNotConfig    ConditionType = "GpfsIBNotConfig"
+
+	// gpu
+	ConditionTypeGpuHung                      ConditionType = "GpuHung"
+	ConditionTypeGpuCheckFailed               ConditionType = "GpuCheckFailed"
+	ConditionTypeGpuRegisterFailed            ConditionType = "GpuRegisterFailed"
+	ConditionTypeHighGpuMemoryTemp            ConditionType = "HighGpuMemoryTemp"
+	ConditionTypeHighGpuTemp                  ConditionType = "HighGpuTemp"
+	ConditionTypeXIDECCMemoryErr              ConditionType = "XIDECCMemoryErr"
+	ConditionTypeXIDHWSystemErr               ConditionType = "XIDHWSystemErr"
+	ConditionTypeGpuRowRemappingPending       ConditionType = "GpuRowRemappingPending"
+	ConditionTypeGpuRowRemappingFailure       ConditionType = "GpuRowRemappingFailure"
+	ConditionTypeGpuTooManyPageRetired        ConditionType = "GpuTooManyPageRetired"
+	ConditionTypeGpuAggSramUncorrectable      ConditionType = "GpuAggSramUncorrectable"
+	ConditionTypeGpuVolSramUncorrectable      ConditionType = "GpuVolSramUncorrectable"
+	ConditionTypeGpuVolDramUncorrectable      ConditionType = "GpuVolDramUncorrectable"
+	ConditionTypeNvidiaFabricManagerNotActive ConditionType = "NvidiaFabricManagerNotActive"
+	ConditionTypeGpuDown                      ConditionType = "GpuDown"
+	ConditionTypeGpuPcieDowngraded            ConditionType = "GpuPcieDowngraded"
+	ConditionTypeGpuGpuHWSlowdown             ConditionType = "GPUHWSlowdown"
+	ConditionTypeGpuNvlinkInactive            ConditionType = "GPUNvlinkInactive"
+	ConditionTypeGPUPersistenceModeNotEnabled ConditionType = "GPUPersistenceModeNotEnabled"
+	ConditionTypeGpuMetricsHang               ConditionType = "GpuMetricsHang"
+
+	// default
 	ConditionTypeNodeCordon                      ConditionType = "NodeCordon"
+	ConditionTypeNodeNotReady                    ConditionType = "NodeNotReady"
+	ConditionTypeNodeHasRestart                  ConditionType = "NodeHasRestart"
 	ConditionTypeKubeletFailedCreatePodContainer ConditionType = "KubeletFailedCreatePodContainer"
 	ConditionTypeNodeFrequentDown                ConditionType = "NodeFrequentDown"
 	ConditionTypeNodeInhibitAll                  ConditionType = "NodeInhibitAll"
-	ConditionTypeNodeNotReady                    ConditionType = "NodeNotReady"
-	ConditionTypeHighDProcessesCount             ConditionType = "HighDProcessesCount"
-	ConditionTypeHighZombieProcessesCount        ConditionType = "HighZombieProcessesCount"
-	ConditionTypePeerMemModuleNotReady           ConditionType = "PeerMemModuleNotReady"
-	ConditionTypePeerMemModuleNotConfig          ConditionType = "PeerMemModuleNotConfig"
+	ConditionTypeNodeHasTerminatingPod           ConditionType = "NodeHasTerminatingPod"
 )
 
 type RemedyAction string
@@ -138,4 +149,5 @@ const (
 	BreakDeadlockRemedyAction RemedyAction = "breakDeadlock"
 	DropCacheRemedyAction     RemedyAction = "DropCache"
 	PeerMemRemedyAction       RemedyAction = "ConfigPeerMem"
+	RestartKubeletAction      RemedyAction = "RestartKubelet"
 )


### PR DESCRIPTION
### Summary
This PR adds initial support for a "device-aware" feature that collects node device status and exposes it via node annotations. It introduces a new DeviceAwareController, related informer/handler code, a CLI flag to enable the feature, and a small deployment manifest change to enable it by default.

### Changes
- Add new package `internal/device_aware`:
  - `device_aware.go` (DeviceAwareController, NodeStatusHandler, Node status handling)
  - `node_condition_informer.go` (node condition informer logic)
  - Writes node annotation `aegis.io/device-errors` with serialized device status.
- Controller integration (`internal/controller/aegis.go`):
  - Import the device-aware package.
  - Add `EnableDeviceAware` to `Configuration`.
  - Create `deviceawareController` in `NewAegisController` and fail fast if creation fails.
  - Register the device-aware controller in the controller run loop (additional goroutine).
  - Adjust wait group and error channel sizes to account for the extra goroutine.
- CLI / runtime flag (`cmd/aegis/main.go`):
  - Add `--device-aware.enable` flag and wire it into configuration (`EnableDeviceAware`).
- Deployment manifest (`deploy/deployment.yaml`):
  - Add `- device-aware.enable=true` to enable the feature via deployment flags.
- Minor other bookkeeping related to adding the new feature.

### Why
- We need to surface per-node device health/status (e.g., device errors) into Kubernetes node annotations for downstream consumption (UIs, alerts, other controllers).
- Introducing this as an optional controller behind a flag lets operators enable it when desired without impacting current behavior.

### How to enable
- Start the controller with `--device-aware.enable=true`, or deploy the updated `deploy/deployment.yaml` which sets this flag.
- When enabled, the DeviceAwareController will run and update node annotations under `aegis.io/device-errors`.