### PR TITLE
Adds a new "None" ticket system to bypass actual ticket creation in non-Aggressive mode while still triggering a DispatchTicketToSRE callback. Implements a no-op `NoneTicketManager`.

### DIFF
--- a/internal/selfhealing/node_sop/baseboard/baseboard.go
+++ b/internal/selfhealing/node_sop/baseboard/baseboard.go
@@ -86,6 +86,11 @@ func (g *baseboard) Execute(ctx context.Context, node string, status *prom.Aegis
 		}
 	}
 
+	if !g.bridge.Aggressive {
+		g.bridge.TicketManager.DispatchTicketToSRE(ctx)
+		return nil
+	}
+
 	cancelled := false
 	switch status.ID {
 	case "fan":

--- a/internal/selfhealing/node_sop/cpu/unhealthy.go
+++ b/internal/selfhealing/node_sop/cpu/unhealthy.go
@@ -49,6 +49,11 @@ func (c *cpuunhealthy) Execute(ctx context.Context, node string, status *prom.Ae
 		klog.Errorf("aegis error run diagnose for node %s %s type: %s %s, err: %s", node, status.Condition, status.Type, status.ID, err)
 	}
 
+	if !c.bridge.Aggressive {
+		c.bridge.TicketManager.DispatchTicketToSRE(ctx)
+		return nil
+	}
+
 	cancelled := false
 	if !basic.CheckNodeIsCritical(ctx, c.bridge, node) {
 		// shutdown

--- a/internal/selfhealing/node_sop/memory/unhealthy.go
+++ b/internal/selfhealing/node_sop/memory/unhealthy.go
@@ -49,6 +49,11 @@ func (n *memoryunhealthy) Execute(ctx context.Context, node string, status *prom
 	if err != nil {
 		klog.Errorf("aegis error run diagnose for node %s %s type: %s %s, err: %s", node, status.Condition, status.Type, status.ID, err)
 	}
+
+	if !n.bridge.Aggressive {
+		n.bridge.TicketManager.DispatchTicketToSRE(ctx)
+		return nil
+	}
 	
 	cancelled := false
 	if !basic.CheckNodeIsCritical(ctx, n.bridge, node) {

--- a/internal/selfhealing/ticket/manager.go
+++ b/internal/selfhealing/ticket/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/scitix/aegis/pkg/nodeticket"
+	"github.com/scitix/aegis/pkg/noneticket"
 	"github.com/scitix/aegis/pkg/opticket"
 	"github.com/scitix/aegis/pkg/ticketmodel"
 	"github.com/scitix/aegis/pkg/uticket"
@@ -13,6 +14,7 @@ import (
 type TicketSystem string
 
 const (
+	TicketSystemNone   TicketSystem = "None"
 	TicketSystemNode   TicketSystem = "Node"
 	TicketSystemScitix TicketSystem = "Scitix"
 	TicketSystemUcp    TicketSystem = "UCP"
@@ -20,6 +22,8 @@ const (
 
 func NewTicketManagerBySystem(ctx context.Context, system TicketSystem, args *ticketmodel.TicketManagerArgs) (ticketmodel.TicketManagerInterface, error) {
 	switch system {
+	case TicketSystemNone:
+		return noneticket.NewNoneTicketManager(ctx, args)
 	case TicketSystemNode:
 		return nodeticket.NewNodeTicketManager(ctx, args)
 	case TicketSystemScitix:

--- a/pkg/noneticket/manager.go
+++ b/pkg/noneticket/manager.go
@@ -1,0 +1,74 @@
+package noneticket
+
+import (
+	"context"
+
+	"github.com/scitix/aegis/pkg/prom"
+	"github.com/scitix/aegis/pkg/ticketmodel"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type NoneTicketManager struct {
+	client kubernetes.Interface
+	node   *corev1.Node
+}
+
+func NewNoneTicketManager(ctx context.Context, args *ticketmodel.TicketManagerArgs) (ticketmodel.TicketManagerInterface, error) {
+	return &NoneTicketManager{
+		client: args.Client,
+		node:   args.Node,
+	}, nil
+}
+
+func (m *NoneTicketManager) Reset(ctx context.Context) error {
+	return nil
+}
+
+func (m *NoneTicketManager) CanDealWithTicket(ctx context.Context) bool {
+	return true
+}
+
+func (m *NoneTicketManager) CheckTicketExists(ctx context.Context) bool {
+	return false
+}
+
+func (m *NoneTicketManager) CheckTicketSupervisor(ctx context.Context, user string) bool {
+	return true
+}
+
+func (m *NoneTicketManager) CreateTicket(ctx context.Context, status *prom.AegisNodeStatus, hardwareType string, customTitle ...string) error {
+	return nil
+}
+
+func (m *NoneTicketManager) CreateComponentTicket(ctx context.Context, title, model, component string) error {
+	return nil
+}
+
+func (m *NoneTicketManager) AdoptTicket(ctx context.Context) error {
+	return nil
+}
+
+func (m *NoneTicketManager) DispatchTicket(ctx context.Context, user string) error {
+	return nil
+}
+
+func (m *NoneTicketManager) DispatchTicketToSRE(ctx context.Context) error {
+	return nil
+}
+
+func (m *NoneTicketManager) ResolveTicket(ctx context.Context, answer, operation string) error {
+	return nil
+}
+
+func (m *NoneTicketManager) CloseTicket(ctx context.Context) error {
+	return nil
+}
+
+func (t *NoneTicketManager) DeleteTicket(ctx context.Context) error {
+	return t.CloseTicket(ctx)
+}
+
+func (m *NoneTicketManager) IsFrequentIssue(ctx context.Context, size, frequency int) (bool, error) {
+	return false, nil
+}

--- a/pkg/noneticket/ticket_ops.go
+++ b/pkg/noneticket/ticket_ops.go
@@ -1,0 +1,73 @@
+package noneticket
+
+import (
+	"context"
+
+	"github.com/scitix/aegis/pkg/ticketmodel"
+	"k8s.io/klog/v2"
+)
+
+// Description Manager Interface
+
+func (m *NoneTicketManager) GetRootCauseDescription(ctx context.Context) (*ticketmodel.TicketCause, error) {
+	klog.Infof("[ticket] AddRootCauseDescription called (no-op in NoneTicketManager)")
+	return nil, nil
+}
+
+func (m *NoneTicketManager) AddRootCauseDescription(ctx context.Context, cause string, condition interface{}) (int, error) {
+	klog.Infof("[ticket] AddRootCauseDescription called with cause: %s, condition: %+v (no-op in NoneTicketManager)", cause, condition)
+	return 0, nil
+}
+
+func (m *NoneTicketManager) AddOrUpdateRootCauseDescription(ctx context.Context, cause string, condition interface{}) (bool, error) {
+	klog.Infof("[ticket] AddOrUpdateRootCauseDescription called with cause: %s, condition: %+v (no-op in NoneTicketManager)", cause, condition)
+	return false, nil
+}
+
+func (m *NoneTicketManager) GetActionCount(ctx context.Context, action ticketmodel.TicketWorkflowAction) (int, error) {
+	klog.Infof("[ticket] GetActionCount called for action: %s (always returns 0 as no-op in NoneTicketManager)", action)
+	return 0, nil
+}
+
+func (m *NoneTicketManager) AddConclusion(ctx context.Context, conclusion string) error {
+	klog.Infof("[ticket] AddConclusion called with content: %s (no-op in NoneTicketManager)", conclusion)
+	return nil
+}
+
+func (m *NoneTicketManager) AddDiagnosis(ctx context.Context, diagnosis []ticketmodel.Diagnose) error {
+	klog.Infof("[ticket] AddDiagnosis called with %d diagnosis items (no-op in NoneTicketManager)", len(diagnosis))
+	return nil
+}
+
+func (m *NoneTicketManager) AddWhySRE(ctx context.Context, whySRE string) error {
+	klog.Infof("[ticket] AddWhySRE called with reason: %s (no-op in NoneTicketManager)", whySRE)
+	return nil
+}
+
+func (m *NoneTicketManager) GetWorkflows(ctx context.Context) ([]ticketmodel.TicketWorkflow, error) {
+	klog.Infof("[ticket] GetWorkflows called (no-op in NoneTicketManager)")
+	return nil, nil
+}
+
+func (m *NoneTicketManager) GetLastWorkflow(ctx context.Context) (*ticketmodel.TicketWorkflow, error) {
+	klog.Infof("[ticket] GetLastWorkflow called (no-op in NoneTicketManager)")
+	return nil, nil
+}
+
+func (m *NoneTicketManager) AddWorkflow(ctx context.Context, action ticketmodel.TicketWorkflowAction, status ticketmodel.TicketWorkflowStatus, message *string) error {
+	klog.Infof("[ticket] AddWorkflow called with action: %s (no-op in NoneTicketManager)", action)
+	return nil
+}
+
+func (m *NoneTicketManager) UpdateWorkflow(ctx context.Context, action ticketmodel.TicketWorkflowAction, status ticketmodel.TicketWorkflowStatus, message *string) error {
+	klog.Infof("[ticket] UpdateWorkflow called with action: %s (no-op in NoneTicketManager)", action)
+	return nil
+}
+
+func (m *NoneTicketManager) AddShutdownDescription(ctx context.Context, status ticketmodel.TicketWorkflowStatus, message *string) error {
+	return nil
+}
+
+func (m *NoneTicketManager) UpdateShutdownDescription(ctx context.Context, status ticketmodel.TicketWorkflowStatus, message *string) error {
+	return nil
+}


### PR DESCRIPTION
## Changes
- In `internal/selfhealing/{baseboard,cpu,memory}`, insert logic: if not in Aggressive mode, call `DispatchTicketToSRE(ctx)` and return early.
- Add a new `TicketSystemNone` enum in `ticket/manager.go`, returning `NoneTicketManager` when selected.
- Introduce `pkg/noneticket/manager.go` and `ticket_ops.go`, implementing `NoneTicketManager` with no-op behavior for all ticket interface methods (CreateTicket, ResolveTicket, GetWorkflows, etc.), with log traces for method invocations.

## Motivation
Provides an option to disable ticket creation in scenarios such as testing or non-critical contexts, while preserving interface compatibility and flow control architecture.

## Risks & Considerations
- Validate that skipping ticket creation in non-Aggressive mode has no unintended side-effects.
- Ensure that external systems expecting tickets are not disrupted.
- Logging in no-op methods could increase noise; monitor accordingly.
